### PR TITLE
pretty print invite command

### DIFF
--- a/event.go
+++ b/event.go
@@ -383,6 +383,10 @@ func (e *Event) Pretty() (out string, ok bool) {
 		return fmt.Sprintf("[*] %s has quit (%s)", e.Source.Name, e.Trailing), true
 	}
 
+	if e.Command == INVITE && len(e.Params) == 1 {
+		return fmt.Sprintf("[*] %s invited to %s by %s", e.Params[0], e.Trailing, e.Source.Name), true
+	}
+
 	if e.Command == KICK && len(e.Params) == 2 {
 		return fmt.Sprintf("[%s] *** %s has kicked %s: %s", e.Params[0], e.Source.Name, e.Params[1], e.Trailing), true
 	}


### PR DESCRIPTION
Somehow, there is currently no if-statement for the [invite message](https://tools.ietf.org/html/rfc2812#section-3.2.7) in the `Pretty()` function of the `Event` type. Thus causing the message to be discarded when invoking `Pretty()`.

This commit adds this missing if-statement to the function.