### PR TITLE
Fix pretty printing of nick messages

### DIFF
--- a/event.go
+++ b/event.go
@@ -387,8 +387,18 @@ func (e *Event) Pretty() (out string, ok bool) {
 		return fmt.Sprintf("[%s] *** %s has kicked %s: %s", e.Params[0], e.Source.Name, e.Params[1], e.Trailing), true
 	}
 
-	if e.Command == NICK && len(e.Params) == 1 {
-		return fmt.Sprintf("[*] %s is now known as %s", e.Source.Name, e.Params[0]), true
+	if e.Command == NICK {
+		// Workaround, see https://github.com/lrstanley/girc/pull/15#issuecomment-413845482
+		var name string
+		if len(e.Params) == 1 {
+			name = e.Params[0]
+		} else if len(e.Trailing) > 0 {
+			name = e.Trailing
+		}
+
+		if name != "" {
+			return fmt.Sprintf("[*] %s is now known as %s", e.Source.Name, name), true
+		}
 	}
 
 	if e.Command == TOPIC && len(e.Params) > 0 {


### PR DESCRIPTION
The nick the user switched to seems to be encoded using
`event.Trailing`, thus `len(event.Params)` is always `0` for nick
messages. This commit fixes this by removing the length check and using
`event.Trailing` instead of `event.Params`.