### PR TITLE
Add a method for converting an Event to a CTCPEvent 

### DIFF
--- a/event.go
+++ b/event.go
@@ -206,6 +206,12 @@ func (e *Event) Copy() *Event {
 	return newEvent
 }
 
+// CTCP returns a CTCPEvent for the given event or nil if the given
+// event is not a CTCP.
+func (e *Event) CTCP() *CTCPEvent {
+	return decodeCTCP(e)
+}
+
 // Equals compares two Events for equality.
 func (e *Event) Equals(ev *Event) bool {
 	if e.Command != ev.Command || e.Trailing != ev.Trailing || len(e.Params) != len(ev.Params) {

--- a/event.go
+++ b/event.go
@@ -361,7 +361,7 @@ func (e *Event) Pretty() (out string, ok bool) {
 	}
 
 	if (e.Command == PRIVMSG || e.Command == NOTICE) && len(e.Params) > 0 {
-		if ctcp := decodeCTCP(e); ctcp != nil {
+		if ctcp := e.CTCP(); ctcp != nil {
 			if ctcp.Reply {
 				return
 			}


### PR DESCRIPTION
I want to solve the following problem with the changes purposed here: I have a handler for the `ALL_EVENTS` command. In this handler I would like to ignore CTCP messages. In order to do that I need to find out if a given `girc.Event` is a CTCP.  This currently doesn't seem to be possible.

girc internally uses the `decodeCTCP` function for this purpose. Unfortunately, this is not exported. This PR therefore adds a `CTCP()` function to the `girc.Event` which calls `decodeCTCP`.

I don't know if that's the best way to solve the problem I laid out above and I don't know why the `decodeCTCP` function wasn't exported in the first place. It might also make sense to entirely replace the `decodeCTCP` function with the `CTCP()` function I purposed in this PR.