### PR TITLE
Preliminary support for the MONITOR command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -359,3 +359,9 @@ func (cmd *Commands) List(channels ...string) {
 func (cmd *Commands) Whowas(user string, amount int) {
 	cmd.c.Send(&Event{Command: WHOWAS, Params: []string{user, string(amount)}})
 }
+
+// Monitor sends a MONITOR query to the server. The results of the query
+// depends on the given modifier, see https://ircv3.net/specs/core/monitor-3.2.html
+func (cmd *Commands) Monitor(modifier rune, args ...string) {
+	cmd.c.Send(&Event{Command: MONITOR, Params: append([]string{string(modifier)}, args...)})
+}

--- a/constants.go
+++ b/constants.go
@@ -268,6 +268,7 @@ const (
 // IRCv3 commands and extensions :: http://ircv3.net/irc/.
 const (
 	AUTHENTICATE = "AUTHENTICATE"
+	MONITOR      = "MONITOR"
 	STARTTLS     = "STARTTLS"
 
 	CAP       = "CAP"
@@ -288,17 +289,22 @@ const (
 
 // Numeric IRC reply mapping for ircv3 :: http://ircv3.net/irc/.
 const (
-	RPL_LOGGEDIN    = "900"
-	RPL_LOGGEDOUT   = "901"
-	RPL_NICKLOCKED  = "902"
-	RPL_SASLSUCCESS = "903"
-	ERR_SASLFAIL    = "904"
-	ERR_SASLTOOLONG = "905"
-	ERR_SASLABORTED = "906"
-	ERR_SASLALREADY = "907"
-	RPL_SASLMECHS   = "908"
-	RPL_STARTTLS    = "670"
-	ERR_STARTTLS    = "691"
+	RPL_LOGGEDIN     = "900"
+	RPL_LOGGEDOUT    = "901"
+	RPL_NICKLOCKED   = "902"
+	RPL_SASLSUCCESS  = "903"
+	ERR_SASLFAIL     = "904"
+	ERR_SASLTOOLONG  = "905"
+	ERR_SASLABORTED  = "906"
+	ERR_SASLALREADY  = "907"
+	RPL_SASLMECHS    = "908"
+	RPL_STARTTLS     = "670"
+	ERR_STARTTLS     = "691"
+	RPL_MONONLINE    = "730"
+	RPL_MONOFFLINE   = "731"
+	RPL_MONLIST      = "732"
+	RPL_ENDOFMONLIST = "733"
+	ERR_MONLISTFULL  = "734"
 )
 
 // Numeric IRC event mapping :: RFC2812; section 5.3.


### PR DESCRIPTION
This commit adds support for the IRCv3.2 MONITOR command [\[1\]][1]. This
includes a new function for sending MONITOR commands to the IRC server
and constants for creating handlers for the server responses.

---

**Discussion:** Currently no fancy abstraction is offered for the MONITOR
command. Meaning the caller can:

1. Send MONITOR commands to the server with invalid modifier, where
   `modifier ∉ {+, -, C, L, S}`.
2. Add a target to the list of targets being monitored which is already
   in that list. Which the client MUST NOT do according to the
   specification.

Both 1. and 2. could be addressed by implementing separate functions for
the different MONITOR command modifiers (e.g. `MonitorAdd()`,
`MonitorDel()`, …) and performing more sanity checks in those functions.
If 2. is not considered an issue and should be resolved by the caller 1.
could alternatively by defining a new type for the modifier.

An entirely different solution would be adding methods for monitoring to
the `User struct`. For example: `User.Monitor(), User.Unmonitor(), …`.

[1]: https://ircv3.net/specs/core/monitor-3.2.html