### PR TITLE
Fix IRC color code bug

### DIFF
--- a/format.go
+++ b/format.go
@@ -113,7 +113,7 @@ func Fmt(text string) string {
 
 		if last > -1 {
 			// A-Z, a-z, and ","
-			if text[i] != ',' && (text[i] <= 'A' || text[i] >= 'Z') && (text[i] <= 'a' || text[i] >= 'z') {
+			if text[i] != ',' && (text[i] < 'A' || text[i] > 'Z') && (text[i] < 'a' || text[i] > 'z') {
 				last = -1
 				continue
 			}

--- a/format_test.go
+++ b/format_test.go
@@ -78,6 +78,8 @@ func TestFormat(t *testing.T) {
 		{name: "nothing", args: args{text: "this is a test."}, want: "this is a test."},
 		{name: "fg and bg", args: args{text: "{red,yellow}test{c}"}, want: "\x0304,08test\x03"},
 		{name: "just bg", args: args{text: "{,yellow}test{c}"}, want: "test\x03"},
+		{name: "just red", args: args{text: "{red}test"}, want: "\x0304test"},
+		{name: "just cyan", args: args{text: "{cyan}test"}, want: "\x0311test"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix IRC color bug preventing some color codes (e.g cyan) from formatting properly.

Test pass after fix:
=== RUN   TestFormat
--- PASS: TestFormat (0.00s)
PASS