### PR TITLE
client.LookupUser should never fail on own user

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -87,6 +87,7 @@ func handleConnect(c *Client, e Event) {
 	if len(e.Params) > 0 {
 		c.state.Lock()
 		c.state.nick = e.Params[0]
+		c.state.createUser(c.state.nick)
 		c.state.Unlock()
 
 		c.state.notify(c, UPDATE_GENERAL)


### PR DESCRIPTION
client.LookupUser searches the data structure filled by
state.createUser. Unfortunately, createUser is only called on JOIN and
NAMES. Therefore LookupUser returns nil when passing ones own nick name
as argument if one didn't join any channels yet.

This seemed unexpected to me. This commit therefore calls createUser for
ones own nick on connect.