### PR TITLE
client: Add GetID() function

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -169,7 +169,7 @@ func handleJOIN(c *Client, e Event) {
 	}
 	c.state.Unlock()
 
-	if e.Source.ID() == ToRFC1459(c.GetNick()) {
+	if e.Source.ID() == c.GetID() {
 		// If it's us, don't just add our user to the list. Run a WHO which
 		// will tell us who exactly is in the entire channel.
 		c.Send(&Event{Command: WHO, Params: []string{channelName, "%tacuhnr,1"}})
@@ -209,7 +209,7 @@ func handlePART(c *Client, e Event) {
 
 	defer c.state.notify(c, UPDATE_STATE)
 
-	if e.Source.ID() == ToRFC1459(c.GetNick()) {
+	if e.Source.ID() == c.GetID() {
 		c.state.Lock()
 		c.state.deleteChannel(channel)
 		c.state.Unlock()
@@ -341,7 +341,7 @@ func handleQUIT(c *Client, e Event) {
 		return
 	}
 
-	if e.Source.ID() == ToRFC1459(c.GetNick()) {
+	if e.Source.ID() == c.GetID() {
 		return
 	}
 

--- a/client.go
+++ b/client.go
@@ -436,6 +436,12 @@ func (c *Client) GetNick() string {
 	return c.state.nick
 }
 
+// Returns an RFC1459 compliant version of the current nickname. Panics if
+// tracking is disabled.
+func (c *Client) GetID() string {
+	return ToRFC1459(c.GetNick())
+}
+
 // GetIdent returns the current ident of the active connection. Panics if
 // tracking is disabled. May be empty, as this is obtained from when we join
 // a channel, as there is no other more efficient method to return this info.

--- a/conn.go
+++ b/conn.go
@@ -376,7 +376,7 @@ func (c *Client) readLoop(ctx context.Context, errs chan error, wg *sync.WaitGro
 			// Check if it's an echo-message.
 			if !c.Config.disableTracking {
 				event.Echo = (event.Command == PRIVMSG || event.Command == NOTICE) &&
-					event.Source != nil && event.Source.ID() == ToRFC1459(c.GetNick())
+					event.Source != nil && event.Source.ID() == c.GetID()
 			}
 
 			c.rx <- event


### PR DESCRIPTION
Makes it a bit less verbose to check if an event originated from once
own client. While at it the existing code was modified accordingly.