### PR TITLE
No need to make lookupUser argument RFC 1459 compliant

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -143,13 +143,13 @@ func handleJOIN(c *Client, e Event) {
 		channel = c.state.lookupChannel(channelName)
 	}
 
-	user := c.state.lookupUser(e.Source.ID())
+	user := c.state.lookupUser(e.Source.Name)
 	if user == nil {
 		if ok := c.state.createUser(e.Source); !ok {
 			c.state.Unlock()
 			return
 		}
-		user = c.state.lookupUser(e.Source.ID())
+		user = c.state.lookupUser(e.Source.Name)
 	}
 
 	defer c.state.notify(c, UPDATE_STATE)
@@ -472,7 +472,7 @@ func handleNAMES(c *Client, e Event) {
 		}
 
 		c.state.createUser(s)
-		user := c.state.lookupUser(s.ID())
+		user := c.state.lookupUser(s.Name)
 		if user == nil {
 			continue
 		}
@@ -501,7 +501,7 @@ func updateLastActive(c *Client, e Event) {
 	c.state.Lock()
 
 	// Update the users last active time, if they exist.
-	user := c.state.lookupUser(e.Source.ID())
+	user := c.state.lookupUser(e.Source.Name)
 	if user == nil {
 		c.state.Unlock()
 		return

--- a/cap.go
+++ b/cap.go
@@ -193,7 +193,7 @@ func handleCHGHOST(c *Client, e Event) {
 	}
 
 	c.state.Lock()
-	user := c.state.lookupUser(e.Source.ID())
+	user := c.state.lookupUser(e.Source.Name)
 	if user != nil {
 		user.Ident = e.Params[0]
 		user.Host = e.Params[1]
@@ -206,7 +206,7 @@ func handleCHGHOST(c *Client, e Event) {
 // when users are no longer away, or when they are away.
 func handleAWAY(c *Client, e Event) {
 	c.state.Lock()
-	user := c.state.lookupUser(e.Source.ID())
+	user := c.state.lookupUser(e.Source.Name)
 	if user != nil {
 		user.Extras.Away = e.Trailing
 	}
@@ -229,7 +229,7 @@ func handleACCOUNT(c *Client, e Event) {
 	}
 
 	c.state.Lock()
-	user := c.state.lookupUser(e.Source.ID())
+	user := c.state.lookupUser(e.Source.Name)
 	if user != nil {
 		user.Extras.Account = account
 	}


### PR DESCRIPTION
The lookupUser function already converts the argument to an RFC 1459
compliant nick and there is no need to convert it twice.