### PR TITLE
RFC: Split messages exceeding maximum length

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,6 +37,8 @@ type Client struct {
 	state *state
 	// initTime represents the creation time of the client.
 	initTime time.Time
+	// Maximum length of an IRC message (excluding the prefix).
+	maxMsgLen int
 	// Handlers is a handler which manages internal and external handlers.
 	Handlers *Caller
 	// CTCP is a handler which manages internal and external CTCP handlers.
@@ -676,6 +678,27 @@ func (c *Client) GetServerOption(key string) (result string, ok bool) {
 	result, ok = c.state.serverOptions[key]
 	c.state.RUnlock()
 	return result, ok
+}
+
+// getServerOptionInt returns the integer value for a given IRC server
+// option name. If the value is not a valid integer or not available,
+// the given fallback value is returned instead.
+//
+// If tracking is disabled, the fallback value is always returned.
+func (c *Client) getServerOptionInt(key string, fallback int) (val int) {
+	if c.Config.disableTracking {
+		return fallback
+	}
+
+	var err error
+	strval, success := c.GetServerOption(key)
+	if success {
+		val, err = strconv.Atoi(strval)
+	}
+	if !success || err != nil {
+		val = fallback
+	}
+	return val
 }
 
 // NetworkName returns the network identifier. E.g. "EsperNet", "ByteIRC".

--- a/conn.go
+++ b/conn.go
@@ -428,13 +428,17 @@ func (c *Client) readLoop(ctx context.Context, errs chan error, wg *sync.WaitGro
 }
 
 // Send sends an event to the server. The event is potentially split
-// into mulitple events if it exceeds the maximum message length. Use
+// into mulitple events if it exceeds the maximum message length. A list
+// of all events, actually send to the server, is returned to allow for
+// further processing of potentially splitted events. Use
 // Client.RunHandlers() if you are simply looking to trigger handlers
 // with an event.
-func (c *Client) Send(event *Event) {
-	for _, e := range splitEvent(c, event) {
+func (c *Client) Send(event *Event) []*Event {
+	events := splitEvent(c, event)
+	for _, e := range events {
 		c.sendSingle(e)
 	}
+	return events
 }
 
 // sendSingle sends a single event to the server. The event is assumed

--- a/conn.go
+++ b/conn.go
@@ -335,6 +335,9 @@ startConn:
 
 	c.write(&Event{Command: USER, Params: []string{c.Config.User, "*", "*", c.Config.Name}})
 
+	// Calculate maximum message length for message splitting algorithm
+	c.maxMsgLen = c.getMaxLen()
+
 	// Send a virtual event allowing hooks for successful socket connection.
 	c.RunHandlers(&Event{Command: INITIALIZED, Params: []string{addr}})
 
@@ -434,7 +437,7 @@ func (c *Client) readLoop(ctx context.Context, errs chan error, wg *sync.WaitGro
 // Client.RunHandlers() if you are simply looking to trigger handlers
 // with an event.
 func (c *Client) Send(event *Event) []*Event {
-	events := splitEvent(c, event)
+	events := c.splitEvent(event)
 	for _, e := range events {
 		c.sendSingle(e)
 	}

--- a/split.go
+++ b/split.go
@@ -18,7 +18,13 @@ var splitFuncs = map[string]splitFunc{
 // getIntOption returns the integer value for a given IRC server option
 // name. If the value is not a valid integer or not available, the
 // given default value is returned instead.
+//
+// If tracking is disabled, the default value is always returned.
 func getIntOption(client *Client, key string, def int) (val int) {
+	if client.Config.disableTracking {
+		return def
+	}
+
 	var err error
 	strval, success := client.GetServerOption(key)
 	if success {

--- a/split.go
+++ b/split.go
@@ -83,6 +83,9 @@ func (c *Client) getMaxLen() int {
 	//   ":" <nickname> "!" <user> "@" <host> " "
 	//
 	maxPrefixLen = 1 + nicklen + 1 + userlen + 1 + hostlen + 1
+	if maxPrefixLen >= maxIRClen {
+		panic("maximum prefix length exceeds maximum IRC message length")
+	}
 
 	return maxIRClen - maxPrefixLen
 }

--- a/split.go
+++ b/split.go
@@ -1,0 +1,119 @@
+package girc
+
+import (
+	"bytes"
+	"strconv"
+	"unicode/utf8"
+)
+
+// splitFunc is the type used for functions implementing splitting of
+// too long IRC messages. The function is passed an event which must be
+// split into multiple and an event length which shall not be exceeded.
+type splitFunc func(event *Event, maxLen int) []*Event
+
+var splitFuncs = map[string]splitFunc{
+	PRIVMSG: splitPRIVMSG,
+}
+
+// getIntOption returns the integer value for a given IRC server option
+// name. If the value is not a valid integer or not available, the
+// given default value is returned instead.
+func getIntOption(client *Client, key string, def int) (val int) {
+	var err error
+	strval, success := client.GetServerOption(key)
+	if success {
+		val, err = strconv.Atoi(strval)
+	}
+	if !success || err != nil {
+		val = def
+	}
+	return val
+}
+
+// maxHostLen returns the maximum possible length of a server message
+// prefix as defined by the following ABNF in RFC 2812:
+//
+//   [ ":" ( servername / ( nickname [ [ "!" user ] "@" host ] ) ) SPACE ]
+//
+func maxPrefixLen(client *Client) int {
+	// Default values taken from https://modern.ircdocs.horse/
+	// Most of these are not actually standardized.
+	nicklen := getIntOption(client, "NICKLEN", 10)
+	userlen := getIntOption(client, "USERLEN", 18)
+	hostlen := getIntOption(client, "HOSTLEN", 63)
+
+	// The code here assumes that `servername` is never used in a
+	// prefix as this function is only concerned with messages send
+	// by ones own client. In accordance with the ABNF from above,
+	// the maximum length is therefore calculated as:
+	//
+	//   ":" <nickname> "!" <user> "@" <host> " "
+	//
+	return 1 + nicklen + 1 + userlen + 1 + hostlen + 1
+}
+
+func splitPRIVMSG(event *Event, maxLen int) (events []*Event) {
+	newMsg := func(text []byte) *Event {
+		e := event.Copy()
+		e.Params[len(event.Params)-1] = string(text)
+		return e
+	}
+
+	// Event used to calculate base length of command, this does not
+	// include the event source and the last parameter.
+	rawEvent := event.Copy()
+	rawEvent.Params = event.Params[0 : len(event.Params)-1]
+
+	// maxTextLen must not be exceeded by the last parameter of the
+	// PRIVMSG. Also include " :" for formatting this last parameter.
+	maxTextLen := maxLen - rawEvent.Len() - len(" :")
+	if maxTextLen <= 0 {
+		return []*Event{event} // TODO: too long without any text
+	}
+
+	b := []byte(event.Last())
+	for len(b) > maxTextLen {
+		idx := bytes.LastIndexByte(b[:maxTextLen], byte(' '))
+		if idx > 0 {
+			// maxTextLen is inclusive → include seperator
+			idx++
+		} else {
+			// maxTextLen is inclusive → include extra byte
+			idx = bytes.LastIndexFunc(b[:maxTextLen+1], utf8.ValidRune)
+		}
+
+		events = append(events, newMsg(b[:idx]))
+		b = b[idx:]
+	}
+	events = append(events, newMsg(b))
+
+	return events
+}
+
+// splitEvent splits a given event into multiple events to satisfy the
+// maximum message length requirements imposed upon the given client by
+// the associated IRC server.
+func splitEvent(client *Client, event *Event) []*Event {
+	// From RFC 2812:
+	//   IRC messages are always lines of characters terminated with a CR-LF
+	//   (Carriage Return - Line Feed) pair, and these messages SHALL NOT
+	//   exceed 512 characters in length, counting all characters including
+	//   the trailing CR-LF.
+	const maxIRClen int = 512 - len("\r\n")
+
+	// We cannot calculate the length of the source part actually
+	// used by the server. Assume the largest possible value and
+	// make sure source is unset for the event to ensure it is not
+	// take into account by `event.Len()`.
+	event.Source = nil // XXX: Operate on a copy instead?
+
+	maxLen := maxIRClen - maxPrefixLen(client)
+	if event.Len() > maxLen {
+		fn, ok := splitFuncs[event.Command]
+		if ok {
+			return fn(event, maxLen)
+		}
+	}
+
+	return []*Event{event}
+}

--- a/split_test.go
+++ b/split_test.go
@@ -1,0 +1,43 @@
+package girc
+
+import (
+	"testing"
+)
+
+func TestPRIVMSG(t *testing.T) {
+	type TestCase struct {
+		Event   *Event
+		MaxLen  int // Text length which shall not be exceeded (maxTextLen)
+		Results []string
+	}
+
+	const target = "#foo"
+	ev := func(text string) *Event {
+		return &Event{Command: PRIVMSG, Params: []string{target, text}}
+	}
+
+	tests := []TestCase{
+		{ev("foo bar baz"), 4, []string{"foo ", "bar ", "baz"}},
+		{ev("1234567890"), 5, []string{"12345", "67890"}},
+		{ev("unsplitted"), 10, []string{"unsplitted"}},
+		{ev("ξ_λχ"), len("λχ"), []string{"ξ_", "λχ"}},
+		{ev("foobar"), 0, []string{"foobar"}},
+	}
+
+	// Keep this in sync with the maxTextLen calculation in split.go
+	rawEvent := &Event{Command: PRIVMSG, Params: []string{target}}
+	off := rawEvent.Len() + len(" :")
+
+	for _, test := range tests {
+		events := splitPRIVMSG(test.Event, test.MaxLen+off)
+		if len(events) != len(test.Results) {
+			t.Fatalf("Expected %d events - got %d\n", len(test.Results), len(events))
+		}
+
+		for n, exp := range test.Results {
+			if events[n].Last() != exp {
+				t.Fatalf("Expected %q - got %q\n", exp, events[n].Last())
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a preliminary implementation of message splitting as proposed in #41. The implementation is far from finished and has bugs all over the place. I just experimented a bit with implementing message splitting and this is what I came up with so far. Consider this a super experimental proof of concept design proposal.

Let me know if you have any thoughts on this. I also have the feeling that implementing this algorithm correctly is super difficult. As such, this definitely needs some extensive unit tests. I only implemented splitting of `PRIVMSG` events so far and did some very very basic tests with my own girc-based IRC client and it seems to work a bit (at least).