### PR TITLE
event: Use different source format for PRIVMSG and NOTICE

### DIFF
--- a/event.go
+++ b/event.go
@@ -363,7 +363,15 @@ func (e *Event) Pretty() (out string, ok bool) {
 
 			return fmt.Sprintf("[*] CTCP query from %s: %s%s", ctcp.Source.Name, ctcp.Command, " "+ctcp.Text), true
 		}
-		return fmt.Sprintf("[%s] (%s) %s", strings.Join(e.Params[0:len(e.Params)-1], ","), e.Source.Name, e.Last()), true
+
+		var source string
+		if e.Command == PRIVMSG {
+			source = fmt.Sprintf("(%s)", e.Source.Name)
+		} else { // NOTICE
+			source = fmt.Sprintf("--%s--", e.Source.Name)
+		}
+
+		return fmt.Sprintf("[%s] (%s) %s", strings.Join(e.Params[0:len(e.Params)-1], ","), source, e.Last()), true
 	}
 
 	if e.Command == RPL_MOTD || e.Command == RPL_MOTDSTART ||


### PR DESCRIPTION
This allows distinguishing the two commands in the output of the
Pretty() function. This is useful for IRC client which use the output of
the Pretty() function for formating IRC messages.