### PR TITLE
Fix conversion errors

### DIFF
--- a/cap_test.go
+++ b/cap_test.go
@@ -104,7 +104,7 @@ func TestTagGetSetCount(t *testing.T) {
 	}
 
 	// Add a hidden ascii value at the end to make it invalid.
-	if err := e.Tags.Set("key", "invalid-value"+string(0x08)); err == nil {
+	if err := e.Tags.Set("key", "invalid-value\b"); err == nil {
 		t.Fatal("tag set of invalid value should have returned error")
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -5,6 +5,7 @@
 package girc
 
 import (
+	"strconv"
 	"errors"
 	"fmt"
 )
@@ -356,7 +357,7 @@ func (cmd *Commands) List(channels ...string) {
 // Whowas sends a WHOWAS query to the server. amount is the amount of results
 // you want back.
 func (cmd *Commands) Whowas(user string, amount int) {
-	cmd.c.Send(&Event{Command: WHOWAS, Params: []string{user, string(amount)}})
+	cmd.c.Send(&Event{Command: WHOWAS, Params: []string{user, strconv.Itoa(amount)}})
 }
 
 // Monitor sends a MONITOR query to the server. The results of the query


### PR DESCRIPTION
Without this commit `go test` fails with go 1.16 with the following error message:

```
./commands.go:360:60: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./cap_test.go:104:46: conversion from untyped int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	github.com/lrstanley/girc [build failed]
```