### PR TITLE
event: Fix serialization of messages with colon but no space

### DIFF
--- a/event.go
+++ b/event.go
@@ -286,7 +286,7 @@ func (e *Event) Bytes() []byte {
 		// buffer.WriteByte(eventSpace)
 
 		for i := 0; i < len(e.Params); i++ {
-			if i == len(e.Params)-1 && (strings.Contains(e.Params[i], " ") || e.Params[i] == "") {
+			if i == len(e.Params)-1 && (strings.ContainsAny(e.Params[i], " :") || e.Params[i] == "") {
 				buffer.WriteString(string(eventSpace) + string(messagePrefix) + e.Params[i])
 				continue
 			}


### PR DESCRIPTION
For messages that contain either a colon **or** a space character, a
messagePrefix needs to be added to the serialized messages. Previously,
a message prefix was only added for messages containing a space
character. This causes messages which only contain a colon, but not a
space to be serialized incorrectly.

For example, prior to this commit a command like `PRIVMSG #foo ::)`,
which should send the message `:)` to the channel `#foo`, was
serialized as `PRIVMSG #foo :)` which only causes a `)` character to be
sent to the channel `#foo`.