### PR TITLE
Make PING timeout configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -155,6 +155,10 @@ type Config struct {
 	// and the client. If this is set to -1, the client will not attempt to
 	// send client -> server PING requests.
 	PingDelay time.Duration
+	// PingTimeout specifies the duration at which girc will assume
+	// that the connection to the server has been lost if no PONG
+	// message has been received in reply to an outstanding PING.
+	PingTimeout time.Duration
 
 	// disableTracking disables all channel and user-level tracking. Useful
 	// for highly embedded scripts with single purposes. This has an exported
@@ -260,6 +264,10 @@ func New(config Config) *Client {
 		c.Config.PingDelay = 20 * time.Second
 	} else if c.Config.PingDelay > (600 * time.Second) {
 		c.Config.PingDelay = 600 * time.Second
+	}
+
+	if c.Config.PingTimeout == 0 {
+		c.Config.PingTimeout = 60 * time.Second
 	}
 
 	envDebug, _ := strconv.ParseBool(os.Getenv("GIRC_DEBUG"))

--- a/conn.go
+++ b/conn.go
@@ -604,9 +604,8 @@ func (c *Client) pingLoop(ctx context.Context, errs chan error, wg *sync.WaitGro
 			}
 
 			c.conn.mu.RLock()
-			if pingSent && time.Since(c.conn.lastPong) > c.Config.PingDelay+(60*time.Second) {
-				// It's 60 seconds over what out ping delay is, connection
-				// has probably dropped.
+			if pingSent && time.Since(c.conn.lastPong) > c.Config.PingDelay+c.Config.PingTimeout {
+				// PingTimeout exceeded, connection has probably dropped.
 				err := ErrTimedOut{
 					TimeSinceSuccess: time.Since(c.conn.lastPong),
 					LastPong:         c.conn.lastPong,


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to girc! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

This commit allows configuring the interval at which girc will drop the connection after not receiving a PONG response to an outstanding PING. Presently, this is hardcoded to `PINGDelay + 60s` and can thus not be configured.

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.

### 📝 Notes to reviewer

*If* my understanding of the code base is correct then PINGTimeout must always be larger then PINGDelay. This is currently only mentioned in the documentation comment but not otherwise enforced. If this is deemed important then I see two potential solutions: (1) Emit an error if this invariant is not satisfied (2) Define PINGTimeout as an offset on PINGDelay. 

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [x] 📝 I have made corresponding changes to the documentation.
- [x] 🧪 I have included tests (if necessary) for this change.
