### PR TITLE
fix: race condition (closes #63)

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -150,35 +150,24 @@ type decodedEvent struct {
 }
 
 func (c *ircConn) decode() <-chan decodedEvent {
-	ch := make(chan decodedEvent)
+	ch := make(chan decodedEvent, 1)
 
 	go func() {
 		defer close(ch)
 
 		line, err := c.io.ReadString(delim)
 		if err != nil {
-			select {
-			case ch <- decodedEvent{err: err}:
-			default:
-			}
-
+			ch <- decodedEvent{err: err}
 			return
 		}
 
 		event := ParseEvent(line)
 		if event == nil {
-			select {
-			case ch <- decodedEvent{err: ErrParseEvent{Line: line}}:
-			default:
-			}
-
+			ch <- decodedEvent{err: ErrParseEvent{Line: line}}
 			return
 		}
 
-		select {
-		case ch <- decodedEvent{event: event}:
-		default:
-		}
+		ch <- decodedEvent{event: event}
 	}()
 
 	return ch


### PR DESCRIPTION
Logic race condition, if the decode goroutine can run before the caller can, the channel returned might not have a receiver yet and then the select/default construct will drop the event and close the channel.

The caller then ends up with a zero-value `decodedEvent` where `decodedEvent.err` and `decodedEvent.event` are both nil which passes the err check at line 434 and might enter line 440 where `decodedEvent.event` is then used as-is with no additional check for it being nil.

Fixed this scenario by giving the returned channel a buffer slot so that `decode` can always send its event.