### PR TITLE
bugfix: <-timer.C after Stop will hang if timer.C is empty

### DIFF
--- a/client.go
+++ b/client.go
@@ -312,11 +312,7 @@ func New(config Config) *Client {
 // the event can't be sent within 30s.
 func (c *Client) receive(e *Event) {
 	t := time.NewTimer(30 * time.Second)
-	defer func() {
-		if !t.Stop() {
-			<-t.C
-		}
-	}()
+	defer t.Stop()
 
 	select {
 	case c.rx <- e:

--- a/conn.go
+++ b/conn.go
@@ -486,11 +486,7 @@ func (c *Client) write(event *Event) {
 	}
 
 	t := time.NewTimer(30 * time.Second)
-	defer func() {
-		if !t.Stop() {
-			<-t.C
-		}
-	}()
+	defer t.Stop()
 
 	select {
 	case c.tx <- event:


### PR DESCRIPTION
see https://github.com/golang/go/issues/27169

Fixes the above issue in the girc code
