### PR TITLE
fix: only reply to CTCP message if it's not a reply message itself

### DIFF
--- a/ctcp.go
+++ b/ctcp.go
@@ -155,7 +155,7 @@ func (c *CTCP) call(client *Client, event *CTCPEvent) {
 		}
 
 		// Send a ERRMSG reply, if we know who sent it.
-		if event.Source != nil && IsValidNick(event.Source.ID()) {
+		if !event.Reply && event.Source != nil && IsValidNick(event.Source.ID()) {
 			client.Cmd.SendCTCPReply(event.Source.ID(), CTCP_ERRMSG, "that is an unknown CTCP query")
 		}
 		return
@@ -263,6 +263,10 @@ func handleCTCPPong(client *Client, ctcp CTCPEvent) {
 // as the os type (darwin, linux, windows, etc) and architecture type (x86,
 // arm, etc).
 func handleCTCPVersion(client *Client, ctcp CTCPEvent) {
+	if ctcp.Reply {
+		return
+	}
+
 	if client.Config.Version != "" {
 		client.Cmd.SendCTCPReply(ctcp.Source.ID(), CTCP_VERSION, client.Config.Version)
 		return
@@ -277,18 +281,30 @@ func handleCTCPVersion(client *Client, ctcp CTCPEvent) {
 
 // handleCTCPSource replies with the public git location of this library.
 func handleCTCPSource(client *Client, ctcp CTCPEvent) {
+	if ctcp.Reply {
+		return
+	}
+
 	client.Cmd.SendCTCPReply(ctcp.Source.ID(), CTCP_SOURCE, "https://github.com/lrstanley/girc")
 }
 
 // handleCTCPTime replies with a RFC 1123 (Z) formatted version of Go's
 // local time.
 func handleCTCPTime(client *Client, ctcp CTCPEvent) {
+	if ctcp.Reply {
+		return
+	}
+
 	client.Cmd.SendCTCPReply(ctcp.Source.ID(), CTCP_TIME, ":"+time.Now().Format(time.RFC1123Z))
 }
 
 // handleCTCPFinger replies with the realname and idle time of the user. This
 // is obsoleted by improvements to the IRC protocol, however still supported.
 func handleCTCPFinger(client *Client, ctcp CTCPEvent) {
+	if ctcp.Reply {
+		return
+	}
+
 	client.conn.mu.RLock()
 	active := client.conn.lastActive
 	client.conn.mu.RUnlock()


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

This fixes some issues I had where it would reply to a CTCP message even though that message was already a reply itself. Normally this probably is not an issue but when using a multiclient bouncer (ZNC in my case), this causes an infinite loop.


### 🧰 Type of change

- [X] Bug fix (non-breaking change which fixes an issue).

### 📝 Notes to reviewer

Basically adds a `if ctcp.Reply` check just like the CTCP PING/PONG messages already had.

### 🤝 Requirements

- [X] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [X] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [X] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [X] 🔎 I have performed a self-review of my own changes.
- [X] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [X] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [X] 📝 I have made corresponding changes to the documentation.
- [X] 🧪 I have included tests (if necessary) for this change.
