### PR TITLE
fix handleTOPIC only supporting modern RPL_TOPIC

### DIFF
--- a/state_test.go
+++ b/state_test.go
@@ -42,12 +42,13 @@ const mockConnStartState = `:dummy.int NOTICE * :*** Looking up your hostname...
 :dummy.int 354 nick 1 #channel nick2 other.int nick2 nick2 :realname2
 :dummy.int 315 nick #channel :End of /WHO list.
 :nick!~user@local.int JOIN #channel2 * :realname
-:dummy.int 332 nick #channel2 :example topic
+:dummy.int 332 nick #channel2 :example init topic
 :dummy.int 353 nick = #channel2 :nick!~user@local.int @nick2!nick2@other.int
 :dummy.int 366 nick #channel2 :End of /NAMES list.
 :dummy.int 354 nick 1 #channel2 ~user local.int nick 0 :realname
 :dummy.int 354 nick 1 #channel2 nick2 other.int nick2 nick2 :realname2
 :dummy.int 315 nick #channel2 :End of /WHO list.
+:dummy.int TOPIC #channel2 :example topic
 `
 
 const mockConnEndState = `:nick2!nick2@other.int QUIT :example reason
@@ -188,6 +189,10 @@ func TestState(t *testing.T) {
 
 		if !user.InChannel("#channel2") {
 			t.Fatal("User.InChannel() returned false for existing channel")
+		}
+
+		if ch2 := c.LookupChannel("#channel2"); ch2.Topic != "example topic" {
+			t.Fatalf("Channel.Topic == %q, want \"example topic\"", ch2.Topic)
 		}
 
 		finishStart <- true


### PR DESCRIPTION

<!--
  🙏 Thanks for submitting a pull request to girc! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

handleTOPIC was using the wrong event parameters when a TOPIC message or (old) RPL_TOPIC was received, it only handles (new) RPL_TOPIC messages correctly.

TOPIC messages are defined as `TOPIC <channel> [:<topic>]` in both specs while RPL_TOPIC differs between RFC1459/RFC2812 and "Modern IRC" such that they are respectively defined as `RPL_TOPIC <channel> :<topic>` and `RPL_TOPIC <client> <channel> :<topic>`.

The old code only correctly parsed the "Modern IRC" RPL_TOPIC variant and not the (old) RPL_TOPIC or TOPIC events, these were instead silently never used in state tracking of the channel topic.

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [x] Bug fix (non-breaking change which fixes an issue).

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [ ] 📝 I have made corresponding changes to the documentation.
- [x] 🧪 I have included tests (if necessary) for this change.
