### PR TITLE
fix: various linter fixes; fix size calculations for tags; update error names

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -102,7 +102,7 @@ func handleConnect(c *Client, e Event) {
 
 // nickCollisionHandler helps prevent the client from having conflicting
 // nicknames with another bot, user, etc.
-func nickCollisionHandler(c *Client, e Event) {
+func nickCollisionHandler(c *Client, _ Event) {
 	if c.Config.HandleNickCollide == nil {
 		c.Cmd.Nick(c.GetNick() + "_")
 		return
@@ -119,7 +119,7 @@ func handlePING(c *Client, e Event) {
 	c.Cmd.Pong(e.Last())
 }
 
-func handlePONG(c *Client, e Event) {
+func handlePONG(c *Client, _ Event) {
 	c.conn.mu.Lock()
 	c.conn.lastPong = time.Now()
 	c.conn.mu.Unlock()
@@ -513,7 +513,6 @@ func handleNAMES(c *Client, e Event) {
 			if s == nil {
 				continue
 			}
-
 		} else {
 			s = &Source{
 				Name: nick,

--- a/cap.go
+++ b/cap.go
@@ -117,6 +117,8 @@ func parseCap(raw string) map[string]map[string]string {
 // handleCAP attempts to find out what IRCv3 capabilities the server supports.
 // This will lock further registration until we have acknowledged (or denied)
 // the capabilities.
+//
+//nolint:nestif,gocognit
 func handleCAP(c *Client, e Event) {
 	c.state.Lock()
 	defer c.state.Unlock()

--- a/cap_tags.go
+++ b/cap_tags.go
@@ -64,7 +64,7 @@ type Tags map[string]string
 func ParseTags(raw string) (t Tags) {
 	t = make(Tags)
 
-	if len(raw) > 0 && raw[0] == prefixTag {
+	if raw != "" && raw[0] == prefixTag {
 		raw = raw[1:]
 	}
 
@@ -143,8 +143,8 @@ func (t Tags) Bytes() []byte {
 		return []byte{}
 	}
 
-	max := len(t)
-	if max == 0 {
+	maxb := len(t)
+	if maxb == 0 {
 		return nil
 	}
 
@@ -170,13 +170,13 @@ func (t Tags) Bytes() []byte {
 		buffer.WriteString(names[i])
 
 		// Write the value as necessary.
-		if len(t[names[i]]) > 0 {
+		if t[names[i]] != "" {
 			buffer.WriteByte(prefixTagValue)
 			buffer.WriteString(t[names[i]])
 		}
 
 		// add the separator ";" between tags.
-		if current < max-1 {
+		if current < maxb-1 {
 			buffer.WriteByte(tagSeparator)
 		}
 
@@ -263,7 +263,7 @@ func (t Tags) Set(key, value string) error {
 
 	value = tagEncoder.Replace(value)
 
-	if len(value) > 0 && !validTagValue(value) {
+	if value != "" && !validTagValue(value) {
 		return fmt.Errorf("tag value %q of key %q is invalid", value, key)
 	}
 

--- a/cap_test.go
+++ b/cap_test.go
@@ -56,7 +56,7 @@ func FuzzParseCap(f *testing.F) {
 		f.Add(tc.in)
 	}
 
-	f.Fuzz(func(t *testing.T, orig string) {
+	f.Fuzz(func(_ *testing.T, orig string) {
 		_ = parseCap(orig)
 	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -101,9 +101,9 @@ func TestClientUptime(t *testing.T) {
 	go mockReadBuffer(conn)
 
 	done := make(chan struct{}, 1)
-	c.Handlers.Add(INITIALIZED, func(c *Client, e Event) { close(done) })
+	c.Handlers.Add(INITIALIZED, func(_ *Client, _ Event) { close(done) })
 
-	go c.MockConnect(server)
+	go c.MockConnect(server) //nolint:errcheck
 	defer c.Close()
 
 	select {
@@ -146,9 +146,9 @@ func TestClientGet(t *testing.T) {
 	go mockReadBuffer(conn)
 
 	done := make(chan struct{}, 1)
-	c.Handlers.Add(INITIALIZED, func(c *Client, e Event) { close(done) })
+	c.Handlers.Add(INITIALIZED, func(_ *Client, _ Event) { close(done) })
 
-	go c.MockConnect(server)
+	go c.MockConnect(server) //nolint:errcheck
 	defer c.Close()
 
 	select {
@@ -179,12 +179,8 @@ func TestClientClose(t *testing.T) {
 	errchan := make(chan error, 1)
 	done := make(chan struct{}, 1)
 
-	c.Handlers.AddBg(CLOSED, func(c *Client, e Event) {
-		close(done)
-	})
-	c.Handlers.AddBg(INITIALIZED, func(c *Client, e Event) {
-		c.Close()
-	})
+	c.Handlers.AddBg(CLOSED, func(_ *Client, _ Event) { close(done) })
+	c.Handlers.AddBg(INITIALIZED, func(c *Client, _ Event) { c.Close() })
 
 	go func() { errchan <- c.MockConnect(server) }()
 

--- a/cmdhandler/cmd.go
+++ b/cmdhandler/cmd.go
@@ -44,7 +44,7 @@ type Command struct {
 func (c *Command) genHelp(prefix string) string {
 	out := "{b}" + prefix + c.Name + "{b}"
 
-	if c.Aliases != nil && len(c.Aliases) > 0 {
+	if len(c.Aliases) > 0 {
 		out += " ({b}" + prefix + strings.Join(c.Aliases, "{b}, {b}"+prefix) + "{b})"
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -26,12 +26,12 @@ func (cmd *Commands) Nick(name string) {
 func (cmd *Commands) Join(channels ...string) {
 	// We can join multiple channels at once, however we need to ensure that
 	// we are not exceeding the line length (see Client.MaxEventLength()).
-	max := cmd.c.MaxEventLength() - len(JOIN) - 1
+	maxLen := cmd.c.MaxEventLength() - len(JOIN) - 1
 
 	var buffer string
 
 	for i := 0; i < len(channels); i++ {
-		if len(buffer+","+channels[i]) > max {
+		if len(buffer+","+channels[i]) > maxLen {
 			cmd.c.Send(&Event{Command: JOIN, Params: []string{buffer}})
 			buffer = ""
 			continue
@@ -330,12 +330,12 @@ func (cmd *Commands) List(channels ...string) {
 
 	// We can LIST multiple channels at once, however we need to ensure that
 	// we are not exceeding the line length (see Client.MaxEventLength()).
-	max := cmd.c.MaxEventLength() - len(JOIN) - 1
+	maxLen := cmd.c.MaxEventLength() - len(JOIN) - 1
 
 	var buffer string
 
 	for i := 0; i < len(channels); i++ {
-		if len(buffer+","+channels[i]) > max {
+		if len(buffer+","+channels[i]) > maxLen {
 			cmd.c.Send(&Event{Command: LIST, Params: []string{buffer}})
 			buffer = ""
 			continue

--- a/conn_test.go
+++ b/conn_test.go
@@ -104,7 +104,7 @@ func mockReadBuffer(conn net.Conn) {
 	// Accept all outgoing writes from the client.
 	b := bufio.NewReader(conn)
 	for {
-		conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 		_, err := b.ReadString(byte('\n'))
 		if err != nil {
 			return

--- a/ctcp.go
+++ b/ctcp.go
@@ -110,7 +110,7 @@ func EncodeCTCPRaw(cmd, text string) (out string) {
 
 	out = string(ctcpDelim) + cmd
 
-	if len(text) > 0 {
+	if text != "" {
 		out += string(eventSpace) + text
 	}
 

--- a/ctcp_test.go
+++ b/ctcp_test.go
@@ -144,7 +144,7 @@ func TestCall(t *testing.T) {
 	var counter uint64
 	ctcp := newCTCP()
 
-	ctcp.Set("TEST", func(client *Client, event CTCPEvent) {
+	ctcp.Set("TEST", func(_ *Client, _ CTCPEvent) {
 		atomic.AddUint64(&counter, 1)
 	})
 
@@ -154,7 +154,7 @@ func TestCall(t *testing.T) {
 	}
 	ctcp.Clear("TEST")
 
-	ctcp.SetBg("TEST", func(client *Client, event CTCPEvent) {
+	ctcp.SetBg("TEST", func(_ *Client, _ CTCPEvent) {
 		atomic.AddUint64(&counter, 1)
 	})
 
@@ -165,7 +165,7 @@ func TestCall(t *testing.T) {
 	}
 	ctcp.Clear("TEST")
 
-	ctcp.Set("*", func(client *Client, event CTCPEvent) {
+	ctcp.Set("*", func(_ *Client, _ CTCPEvent) {
 		atomic.AddUint64(&counter, 1)
 	})
 
@@ -185,12 +185,12 @@ func TestCall(t *testing.T) {
 func TestSet(t *testing.T) {
 	ctcp := newCTCP()
 
-	ctcp.Set("TEST-1", func(client *Client, event CTCPEvent) {})
+	ctcp.Set("TEST-1", func(_ *Client, _ CTCPEvent) {})
 	if _, ok := ctcp.handlers["TEST"]; ok {
 		t.Fatal("Set('TEST') allowed invalid command")
 	}
 
-	ctcp.Set("TEST", func(client *Client, event CTCPEvent) {})
+	ctcp.Set("TEST", func(_ *Client, _ CTCPEvent) {})
 	// Make sure it's there.
 	if _, ok := ctcp.handlers["TEST"]; !ok {
 		t.Fatal("store: Set('TEST') didn't set")
@@ -200,7 +200,7 @@ func TestSet(t *testing.T) {
 func TestClear(t *testing.T) {
 	ctcp := newCTCP()
 
-	ctcp.Set("TEST", func(client *Client, event CTCPEvent) {})
+	ctcp.Set("TEST", func(_ *Client, _ CTCPEvent) {})
 	ctcp.Clear("TEST")
 
 	if _, ok := ctcp.handlers["TEST"]; ok {
@@ -211,8 +211,8 @@ func TestClear(t *testing.T) {
 func TestClearAll(t *testing.T) {
 	ctcp := newCTCP()
 
-	ctcp.Set("TEST1", func(client *Client, event CTCPEvent) {})
-	ctcp.Set("TEST2", func(client *Client, event CTCPEvent) {})
+	ctcp.Set("TEST1", func(_ *Client, _ CTCPEvent) {})
+	ctcp.Set("TEST2", func(_ *Client, _ CTCPEvent) {})
 	ctcp.ClearAll()
 
 	_, first := ctcp.handlers["TEST1"]

--- a/event_test.go
+++ b/event_test.go
@@ -399,7 +399,7 @@ var testsIRCDocs = []string{
 	":SomeOp MODE #channel +oo SomeUser :AnotherUser",
 }
 
-func TestEventIRCDocsParseTests(t *testing.T) {
+func TestEventIRCDocsParseTests(_ *testing.T) {
 	for _, tt := range testsIRCDocs {
 		// Basic test to just verify it doesn't panic.
 		_ = ParseEvent(tt)

--- a/example/main.go
+++ b/example/main.go
@@ -22,13 +22,6 @@ func main() {
 		Debug:  os.Stdout,
 	})
 
-	// client.Handlers.AddBg(girc.CONNECTED, func(c *girc.Client, e girc.Event) {
-	// 	// c.Cmd.Join("#dev")
-	// 	time.Sleep(30 * time.Second)
-	// 	c.Quit("bye")
-	// 	// c.Cmd.SendRaw("ERROR")
-	// })
-
 	// An example of how you would add reconnect logic.
 	for {
 		if err := client.Connect(); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -5,7 +5,7 @@
 package girc_test
 
 import (
-	"log"
+	"log" //nolint:depguard
 	"os"
 	"strings"
 	"time"
@@ -13,7 +13,7 @@ import (
 	"github.com/lrstanley/girc"
 )
 
-func ExampleNew() {
+func ExampleNew() { //nolint:testableexamples
 	client := girc.New(girc.Config{
 		Server: "irc.byteirc.org",
 		Port:   6667,
@@ -29,7 +29,7 @@ func ExampleNew() {
 }
 
 // The bare-minimum needed to get started with girc. Just connects and idles.
-func Example_bare() {
+func Example_bare() { //nolint:testableexamples
 	client := girc.New(girc.Config{
 		Server: "irc.byteirc.org",
 		Port:   6667,
@@ -45,7 +45,7 @@ func Example_bare() {
 
 // Very simple example that connects, joins a channel, and responds to
 // "hello" with "hello world!".
-func Example_simple() {
+func Example_simple() { //nolint:testableexamples
 	client := girc.New(girc.Config{
 		Server: "irc.byteirc.org",
 		Port:   6667,
@@ -55,7 +55,7 @@ func Example_simple() {
 		Debug:  os.Stdout,
 	})
 
-	client.Handlers.Add(girc.CONNECTED, func(c *girc.Client, e girc.Event) {
+	client.Handlers.Add(girc.CONNECTED, func(c *girc.Client, _ girc.Event) {
 		c.Cmd.Join("#dev")
 	})
 
@@ -85,7 +85,7 @@ func Example_simple() {
 
 // Another basic example, however with this, we add simple !<command>
 // responses to things. E.g. "!hello", "!stop", and "!restart".
-func Example_commands() {
+func Example_commands() { //nolint:testableexamples
 	client := girc.New(girc.Config{
 		Server: "irc.byteirc.org",
 		Port:   6667,
@@ -95,7 +95,7 @@ func Example_commands() {
 		Out:    os.Stdout,
 	})
 
-	client.Handlers.Add(girc.CONNECTED, func(c *girc.Client, e girc.Event) {
+	client.Handlers.Add(girc.CONNECTED, func(c *girc.Client, _ girc.Event) {
 		c.Cmd.Join("#channel", "#other-channel")
 	})
 

--- a/format.go
+++ b/format.go
@@ -83,7 +83,7 @@ func Fmt(text string) string {
 			continue
 		}
 
-		if text[i] == fmtCloseChar && last > -1 {
+		if text[i] == fmtCloseChar && last > -1 { //nolint:nestif
 			code := strings.ToLower(text[last+1 : i])
 
 			// Check to see if they're passing in a second (background) color
@@ -381,7 +381,7 @@ func sliceInsert(input []string, i int, v ...string) []string {
 //     that are above maxWordSplitLength characters, split the word into chunks to fit the
 //
 // maximum width.
-func splitMessage(input string, maxWidth int) (output []string) {
+func splitMessage(input string, maxWidth int) (output []string) { //nolint:gocognit
 	input = strings.ToValidUTF8(input, "?")
 
 	words := strings.FieldsFunc(strings.TrimSpace(input), func(r rune) bool {

--- a/format_test.go
+++ b/format_test.go
@@ -232,7 +232,7 @@ func FuzzValidNick(f *testing.F) {
 		f.Add(tc.test)
 	}
 
-	f.Fuzz(func(t *testing.T, orig string) {
+	f.Fuzz(func(_ *testing.T, orig string) {
 		_ = IsValidNick(orig)
 	})
 }
@@ -271,7 +271,7 @@ func FuzzValidChannel(f *testing.F) {
 		f.Add(tc.test)
 	}
 
-	f.Fuzz(func(t *testing.T, orig string) {
+	f.Fuzz(func(_ *testing.T, orig string) {
 		_ = IsValidChannel(orig)
 	})
 }
@@ -306,7 +306,7 @@ func FuzzValidUser(f *testing.F) {
 		f.Add(tc.test)
 	}
 
-	f.Fuzz(func(t *testing.T, orig string) {
+	f.Fuzz(func(_ *testing.T, orig string) {
 		_ = IsValidUser(orig)
 	})
 }
@@ -442,7 +442,7 @@ func FuzzGlob(f *testing.F) {
 		f.Add(tc, tc)
 	}
 
-	f.Fuzz(func(t *testing.T, orig, orig2 string) {
+	f.Fuzz(func(_ *testing.T, orig, orig2 string) {
 		_ = Glob(orig, orig2)
 	})
 }

--- a/handler.go
+++ b/handler.go
@@ -6,8 +6,8 @@ package girc
 
 import (
 	"fmt"
-	"log"
-	"math/rand"
+	"log"       //nolint:depguard // min go version we support doesn't support slog.
+	"math/rand" //nolint:depguard // min go version we support doesn't support v2.
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -145,7 +145,7 @@ func (c *Caller) cuid(cmd string, n int) (cuid, uid string) {
 	b := make([]byte, n)
 
 	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))] //nolint:gosec // not used for cryptographic purposes.
 	}
 
 	return cmd + ":" + string(b), string(b)
@@ -264,9 +264,7 @@ func (c *Caller) Clear(cmd string) {
 	cmd = strings.ToUpper(cmd)
 
 	c.mu.Lock()
-	if _, ok := c.external[cmd]; ok {
-		delete(c.external, cmd)
-	}
+	delete(c.external, cmd)
 	c.mu.Unlock()
 
 	c.debug.Printf("cleared external handlers for %s", cmd)
@@ -496,8 +494,8 @@ func (e *HandlerError) String() string {
 // debug log (see Config.Debug), or os.Stdout if Config.Debug is unset.
 func DefaultRecoverHandler(client *Client, err *HandlerError) {
 	if client.Config.Debug == nil {
-		fmt.Println(err.Error())
-		fmt.Println(err.String())
+		fmt.Println(err.Error())  //nolint:forbidigo
+		fmt.Println(err.String()) //nolint:forbidigo
 		return
 	}
 

--- a/modes.go
+++ b/modes.go
@@ -56,15 +56,12 @@ type CModes struct {
 
 // Copy returns a deep copy of CModes.
 func (c *CModes) Copy() (nc CModes) {
-	nc = CModes{}
 	nc = *c
 
 	nc.modes = make([]CMode, len(c.modes))
 
 	// Copy modes.
-	for i := 0; i < len(c.modes); i++ {
-		nc.modes[i] = c.modes[i]
-	}
+	copy(nc.modes, c.modes)
 
 	return nc
 }
@@ -72,8 +69,7 @@ func (c *CModes) Copy() (nc CModes) {
 // String returns a complete set of modes for this given state (change?). For
 // example, "+a-b+cde some-arg".
 func (c *CModes) String() string {
-	var out string
-	var args string
+	var out, args string
 
 	if len(c.modes) > 0 {
 		out += "+"
@@ -82,7 +78,7 @@ func (c *CModes) String() string {
 	for i := 0; i < len(c.modes); i++ {
 		out += string(c.modes[i].name)
 
-		if len(c.modes[i].args) > 0 {
+		if c.modes[i].args != "" {
 			args += " " + c.modes[i].args
 		}
 	}
@@ -445,7 +441,7 @@ func (p *UserPerms) remove(channel string) {
 // Perms contains all channel-based user permissions. The minimum op, and
 // voice should be supported on all networks. This also supports non-rfc
 // Owner, Admin, and HalfOp, if the network has support for it.
-type Perms struct {
+type Perms struct { //nolint:recvcheck
 	// Owner (non-rfc) indicates that the user has full permissions to the
 	// channel. More than one user can have owner permission.
 	Owner bool `json:"owner"`
@@ -547,5 +543,5 @@ func parseUserPrefix(raw string) (modes, nick string, success bool) {
 		return modes, raw[i:], true
 	}
 
-	return
+	return modes, nick, success
 }

--- a/state.go
+++ b/state.go
@@ -130,7 +130,7 @@ type User struct {
 // Channels returns a reference of *Channels that the client knows the user
 // is in. If you're just looking for the namme of the channels, use
 // User.ChannelList.
-func (u User) Channels(c *Client) []*Channel {
+func (u *User) Channels(c *Client) []*Channel {
 	if c == nil {
 		panic("nil Client provided")
 	}
@@ -244,7 +244,7 @@ type Channel struct {
 
 // Users returns a reference of *Users that the client knows the channel has
 // If you're just looking for just the name of the users, use Channnel.UserList.
-func (ch Channel) Users(c *Client) []*User {
+func (ch *Channel) Users(c *Client) []*User {
 	if c == nil {
 		panic("nil Client provided")
 	}
@@ -265,7 +265,7 @@ func (ch Channel) Users(c *Client) []*User {
 
 // Trusted returns a list of users which have voice or greater in the given
 // channel. See Perms.IsTrusted() for more information.
-func (ch Channel) Trusted(c *Client) []*User {
+func (ch *Channel) Trusted(c *Client) []*User {
 	if c == nil {
 		panic("nil Client provided")
 	}
@@ -292,7 +292,7 @@ func (ch Channel) Trusted(c *Client) []*User {
 // Admins returns a list of users which have half-op (if supported), or
 // greater permissions (op, admin, owner, etc) in the given channel. See
 // Perms.IsAdmin() for more information.
-func (ch Channel) Admins(c *Client) []*User {
+func (ch *Channel) Admins(c *Client) []*User {
 	if c == nil {
 		panic("nil Client provided")
 	}
@@ -389,7 +389,7 @@ func (s *state) createChannel(name string) (ok bool) {
 	supported := s.chanModes()
 	prefixes, _ := parsePrefixes(s.userPrefixes())
 
-	if _, ok := s.channels[ToRFC1459(name)]; ok {
+	if _, sok := s.channels[ToRFC1459(name)]; sok {
 		return false
 	}
 
@@ -440,7 +440,7 @@ func (s *state) lookupUser(name string) *User {
 
 // createUser creates the user in state, if not already done.
 func (s *state) createUser(src *Source) (ok bool) {
-	if _, ok := s.users[src.ID()]; ok {
+	if _, sok := s.users[src.ID()]; sok {
 		// User already exists.
 		return false
 	}
@@ -544,15 +544,20 @@ func (s *strictTransport) enabled() bool {
 	return s.upgradePort > 0
 }
 
-// ErrSTSUpgradeFailed is an error that occurs when a connection that was attempted
+// ErrSTSUpgradeFailed is an alias to STSUpgradeError.
+//
+// Deprecated: use STSUpgradeError instead.
+type ErrSTSUpgradeFailed = STSUpgradeError //nolint:errname
+
+// STSUpgradeError is an error that occurs when a connection that was attempted
 // to be upgraded via a strict transport policy, failed. This does not necessarily
 // indicate that STS was to blame, but the underlying connection failed for some
 // reason.
-type ErrSTSUpgradeFailed struct {
+type STSUpgradeError struct {
 	Err error
 }
 
-func (e ErrSTSUpgradeFailed) Error() string {
+func (e STSUpgradeError) Error() string {
 	return fmt.Sprintf("fail to upgrade to secure (sts) connection: %v", e.Err)
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -198,11 +198,11 @@ func TestState(t *testing.T) {
 		finishStart <- true
 	})
 
-	cuid := c.Handlers.AddBg(UPDATE_STATE, func(c *Client, e Event) {
+	cuid := c.Handlers.AddBg(UPDATE_STATE, func(_ *Client, _ Event) {
 		bounceStart <- true
 	})
 
-	conn.SetDeadline(time.Now().Add(5 * time.Second))
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
 	_, err := conn.Write([]byte(mockConnStartState))
 	if err != nil {
 		panic(err)
@@ -247,11 +247,11 @@ func TestState(t *testing.T) {
 		finishEnd <- true
 	})
 
-	cuid = c.Handlers.AddBg(UPDATE_STATE, func(c *Client, e Event) {
+	cuid = c.Handlers.AddBg(UPDATE_STATE, func(_ *Client, _ Event) {
 		bounceEnd <- true
 	})
 
-	conn.SetDeadline(time.Now().Add(5 * time.Second))
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
 	_, err = conn.Write([]byte(mockConnEndState))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

- `Err<name>` -> `<name>Error`, with type aliases added and deprecation notices. This change should be backwards compatible, however, users should still switch to the new names if possible.
- Various linter fixes
- Fix `LenOpts` not abiding by `includeTags`.

### 🧰 Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [x] 📝 I have made corresponding changes to the documentation.
- [x] 🧪 I have included tests (if necessary) for this change.
