### PR TITLE
feat: new SendRawNoSplit function to bypass split

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -218,6 +218,19 @@ func (cmd *Commands) SendRawf(format string, a ...interface{}) error {
 	return cmd.SendRaw(fmt.Sprintf(format, a...))
 }
 
+// SendRawNoSplit sends a raw string directly to the server without any splitting
+// or length checking. Use with caution - this bypasses all safety checks.
+func (cmd *Commands) SendRawNoSplit(raw string) error {
+	event := ParseEvent(raw)
+	if event == nil {
+		return errors.New("invalid event: " + raw)
+	}
+
+	// Call write directly to bypass Send's splitting logic
+	cmd.c.write(event)
+	return nil
+}
+
 // Topic sets the topic of channel to message. Does not verify the length
 // of the topic.
 func (cmd *Commands) Topic(channel, message string) {


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

A new function `SendRawNoSplit` to bypass the existing `split` function as it's not entirely suitable for playing IRC ascii art.

Before:
<img width="729" height="551" alt="image" src="https://github.com/user-attachments/assets/0c656965-86b3-4ad3-b434-b0bf9391fc77" />

After:
<img width="727" height="548" alt="image" src="https://github.com/user-attachments/assets/37ec2c74-6670-4394-a8d7-e17a5a4f574e" />

  **Root Cause:** The message flow `SendRaw()` → `Send()` → `event.split()` → `splitMessage()` would break ASCII art by:
  - Splitting lines into "words" based on whitespace
  - Reassembling with added spaces between words
  - Force-splitting on punctuation characters common in ASCII art

  **Solution:** Added `SendRawNoSplit()` method to girc library that bypasses the splitting logic entirely by calling
  `write()` directly, preserving the exact formatting of ASCII art lines. The developer can use at their own risk.

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.

### 📝 Notes to reviewer

Scroll some colorful ASCII art and see the difference!

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [ ] 📝 I have made corresponding changes to the documentation.
- [ ] 🧪 I have included tests (if necessary) for this change.
