### PR TITLE
feat: add config field to skip auto-join WHO and MODE

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -174,10 +174,14 @@ func handleJOIN(c *Client, e Event) {
 	if e.Source.ID() == c.GetID() {
 		// If it's us, don't just add our user to the list. Run a WHO which
 		// will tell us who exactly is in the entire channel.
-		c.Send(&Event{Command: WHO, Params: []string{channelName, "%tacuhnr,1"}})
+		if !c.Config.DisableAutoWhoOnJoin {
+			c.Send(&Event{Command: WHO, Params: []string{channelName, "%tacuhnr,1"}})
+		}
 
 		// Also send a MODE to obtain the list of channel modes.
-		c.Send(&Event{Command: MODE, Params: []string{channelName}})
+		if !c.Config.DisableAutoModeOnJoin {
+			c.Send(&Event{Command: MODE, Params: []string{channelName}})
+		}
 
 		// Update our ident and host too, in state -- since there is no
 		// cleaner method to do this.

--- a/client.go
+++ b/client.go
@@ -107,6 +107,13 @@ type Config struct {
 	// strict transport policy expires and the first attempt to reconnect back to
 	// the tls version fails.
 	DisableSTSFallback bool
+	// DisableAutoWhoOnJoin disables the automatic WHO request sent when this
+	// client joins a channel. Channel/user tracking remains enabled, and can
+	// still be populated by NAMES replies and subsequent channel events.
+	DisableAutoWhoOnJoin bool
+	// DisableAutoModeOnJoin disables the automatic MODE request sent when this
+	// client joins a channel.
+	DisableAutoModeOnJoin bool
 	// TLSConfig is an optional user-supplied tls configuration, used during
 	// socket creation to the server. SSL must be enabled for this to be used.
 	// This only has an affect during the dial process.


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to girc! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR
<!-- REQUIRED:
  Please include a summary of the change and which issue is fixed, or what feature is
  implemented. Include relevant motivation and context.
-->
Allow clients to disable girc's automatic self-JOIN WHO and MODE requests independently, while keeping channel/user tracking enabled to keep possible to rely on state lookups.

girc currently sends `WHO <channel>` and `MODE <channel>` whenever the client joins a channel. That is useful as the default because it hydrates channel/user and mode state eagerly.
However, some clients join many channels and already maintain enough UI/state from `NAMES` replies plus incremental `JOIN`, `PART`, `NICK`, and `MODE` events. For those clients, the automatic per-channel WHO/MODE burst can be a significant startup cost.

`DisableTracking()` is not a good fit for this case because it disables too much: I would still need `LookupChannel`, `LookupUser`, `IsInChannel`, etc.

So, this change adds two independent config fields:
- `DisableAutoWhoOnJoin`
- `DisableAutoModeOnJoin`

Both default to false, preserving existing behavior. When enabled, they only suppress the automatic requests sent after the client’s own JOIN. Tracking remains enabled and can still be populated by NAMES replies and subsequent channel events.

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.

### 📝 Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR. If necessary,
  include things like screenshots (where beneficial), to help demonstrate the changes.
-->

### 🤝 Requirements

- [X] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [X] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [X] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [X] 🔎 I have performed a self-review of my own changes.
- [X] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [X] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [ ] 📝 I have made corresponding changes to the documentation.
- [ ] 🧪 I have included tests (if necessary) for this change.
